### PR TITLE
spec helper: add missing require for ostruct

### DIFF
--- a/spec/mock_vsphere.rb
+++ b/spec/mock_vsphere.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 class MockRbVmomiSnapshot
   attr_accessor :name, :rootSnapshotList, :childSnapshotList
 


### PR DESCRIPTION
I think this was pulled in as a transitive dependency or by an older ruby version.