### PR TITLE
fail if datacenter/datastore could not be found

### DIFF
--- a/lib/beaker/hypervisor/vsphere_helper.rb
+++ b/lib/beaker/hypervisor/vsphere_helper.rb
@@ -106,8 +106,8 @@ class VsphereHelper
   end
 
   def find_datastore(dc, datastorename)
-    datacenter = @connection.serviceInstance.find_datacenter(dc)
-    datacenter.find_datastore(datastorename)
+    datacenter = @connection.serviceInstance.find_datacenter(dc) || raise("datacenter #{dc} not found")
+    datacenter.find_datastore(datastorename) || raise("datastore #{datastorename} not found in datacenter #{dc}")
   end
 
   def find_folder(dc, foldername)


### PR DESCRIPTION
This is based on some manual testing and
https://github.com/ManageIQ/rbvmomi2?tab=readme-ov-file#usage. previously we ignored this failure case which results in a nilclass exception somewhere else.